### PR TITLE
Add gif support

### DIFF
--- a/bot/arcweld.go
+++ b/bot/arcweld.go
@@ -2,7 +2,6 @@ package bot
 
 import (
 	"fmt"
-	"io"
 
 	"gopkg.in/gographics/imagick.v2/imagick"
 )
@@ -16,31 +15,25 @@ func (args ArcweldArgs) GetImageURL() string {
 }
 
 // Arcweld destroys an image via a combination of operations.
-func Arcweld(src []byte, dest io.Writer, args ArcweldArgs) error {
-	wand := imagick.NewMagickWand()
-	err := wand.ReadImageBlob(src)
+func Arcweld(wand *imagick.MagickWand, args ArcweldArgs) ([]*imagick.MagickWand, error) {
+	err := wand.EvaluateImageChannel(imagick.CHANNEL_RED, imagick.EVAL_OP_LEFT_SHIFT, 1)
 	if err != nil {
-		return fmt.Errorf("error reading image: %w", err)
-	}
-
-	err = wand.EvaluateImageChannel(imagick.CHANNEL_RED, imagick.EVAL_OP_LEFT_SHIFT, 1)
-	if err != nil {
-		return fmt.Errorf("error left-shifting red channel: %w", err)
+		return nil, fmt.Errorf("error left-shifting red channel: %w", err)
 	}
 
 	err = wand.ContrastStretchImage(0.3, 0.3)
 	if err != nil {
-		return fmt.Errorf("error contrast stretching image: %w", err)
+		return nil, fmt.Errorf("error contrast stretching image: %w", err)
 	}
 
 	err = wand.EvaluateImageChannel(imagick.CHANNEL_RED, imagick.EVAL_OP_THRESHOLD_BLACK, 0.9)
 	if err != nil {
-		return fmt.Errorf("error running threshold black: %w", err)
+		return nil, fmt.Errorf("error running threshold black: %w", err)
 	}
 
 	err = wand.SharpenImage(0, 0)
 	if err != nil {
-		return fmt.Errorf("error sharpening image: %w", err)
+		return nil, fmt.Errorf("error sharpening image: %w", err)
 	}
 
 	width := wand.GetImageWidth()
@@ -48,7 +41,7 @@ func Arcweld(src []byte, dest io.Writer, args ArcweldArgs) error {
 
 	err = wand.LiquidRescaleImage(width/2, height/3, 1, 0)
 	if err != nil {
-		return fmt.Errorf("error liquid rescaling: %w", err)
+		return nil, fmt.Errorf("error liquid rescaling: %w", err)
 	}
 
 	width = wand.GetImageWidth()
@@ -56,23 +49,18 @@ func Arcweld(src []byte, dest io.Writer, args ArcweldArgs) error {
 
 	err = wand.LiquidRescaleImage(width*2, height*3, 0.4, 0)
 	if err != nil {
-		return fmt.Errorf("error liquid rescaling: %w", err)
+		return nil, fmt.Errorf("error liquid rescaling: %w", err)
 	}
 
 	err = wand.ImplodeImage(0.2)
 	if err != nil {
-		return fmt.Errorf("error imploding image: %w", err)
+		return nil, fmt.Errorf("error imploding image: %w", err)
 	}
 
 	err = wand.QuantizeImage(8, imagick.COLORSPACE_RGB, 0, true, false)
 	if err != nil {
-		return fmt.Errorf("error quantizing image: %w", err)
+		return nil, fmt.Errorf("error quantizing image: %w", err)
 	}
 
-	_, err = dest.Write(wand.GetImageBlob())
-	if err != nil {
-		return fmt.Errorf("error writing image: %w", err)
-	}
-
-	return nil
+	return []*imagick.MagickWand{wand}, nil
 }

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -65,6 +65,7 @@ func New() (*Borik, error) {
 	log.Debug().Msg("Registering commands")
 	_ = parser.NewCommand("", "Magikify an image.", MakeImageOpCommand(Magik))
 	_ = parser.NewCommand("magik", "Magikify an image.", MakeImageOpCommand(Magik))
+	_ = parser.NewCommand("gmagik", "Repeatedly magikify an image.", MakeImageOpCommand(Gmagik))
 	_ = parser.NewCommand("arcweld", "Arc-weld an image.", MakeImageOpCommand(Arcweld))
 	_ = parser.NewCommand("malt", "Malt an image.", MakeImageOpCommand(Malt))
 	_ = parser.NewCommand("help", "Get help for available commands.", HelpCommand)

--- a/bot/gmagik.go
+++ b/bot/gmagik.go
@@ -1,0 +1,35 @@
+package bot
+
+import (
+	"fmt"
+
+	"gopkg.in/gographics/imagick.v2/imagick"
+)
+
+type GmagikArgs struct {
+	ImageURL   string  `default:"" description:"URL to the image to process. Leave blank to automatically attempt to find an image."`
+	Scale      float64 `default:"1" description:"Scale of the magikification. Larger numbers produce more destroyed images."`
+	Iterations uint    `default:"10" description:"Number of iterations of magikification to run."`
+}
+
+func (args GmagikArgs) GetImageURL() string {
+	return args.ImageURL
+}
+
+// Gmagik runs content-aware scaling on an image.
+func Gmagik(wand *imagick.MagickWand, args GmagikArgs) ([]*imagick.MagickWand, error) {
+	var results []*imagick.MagickWand
+
+	lastFrame := wand
+
+	for i := uint(0); i < args.Iterations; i++ {
+		newFrame, err := Magik(lastFrame.Clone(), MagikArgs{Scale: args.Scale})
+		if err != nil {
+			return nil, fmt.Errorf("error running magik: %w", err)
+		}
+		lastFrame = newFrame[0]
+		results = append(results, lastFrame)
+	}
+
+	return results, nil
+}

--- a/bot/gmagik.go
+++ b/bot/gmagik.go
@@ -9,7 +9,7 @@ import (
 type GmagikArgs struct {
 	ImageURL   string  `default:"" description:"URL to the image to process. Leave blank to automatically attempt to find an image."`
 	Scale      float64 `default:"1" description:"Scale of the magikification. Larger numbers produce more destroyed images."`
-	Iterations uint    `default:"10" description:"Number of iterations of magikification to run."`
+	Iterations uint    `default:"5" description:"Number of iterations of magikification to run."`
 }
 
 func (args GmagikArgs) GetImageURL() string {

--- a/bot/malt.go
+++ b/bot/malt.go
@@ -2,7 +2,6 @@ package bot
 
 import (
 	"fmt"
-	"io"
 
 	"gopkg.in/gographics/imagick.v2/imagick"
 )
@@ -17,40 +16,29 @@ func (args MaltArgs) GetImageURL() string {
 }
 
 // Malt mixes an image via a combination of operations.
-func Malt(src []byte, dest io.Writer, args MaltArgs) error {
-	wand := imagick.NewMagickWand()
-	err := wand.ReadImageBlob(src)
-	if err != nil {
-		return fmt.Errorf("error reading image: %w", err)
-	}
-
+func Malt(wand *imagick.MagickWand, args MaltArgs) ([]*imagick.MagickWand, error) {
 	width := wand.GetImageWidth()
 	height := wand.GetImageHeight()
 
-	err = wand.SwirlImage(args.Degree)
+	err := wand.SwirlImage(args.Degree)
 	if err != nil {
-		return fmt.Errorf("error while attempting to swirl: %w", err)
+		return nil, fmt.Errorf("error while attempting to swirl: %w", err)
 	}
 
 	err = wand.LiquidRescaleImage(width/2, height/2, 1, 0)
 	if err != nil {
-		return fmt.Errorf("error while attempting to liquid rescale: %w", err)
+		return nil, fmt.Errorf("error while attempting to liquid rescale: %w", err)
 	}
 
 	err = wand.SwirlImage(args.Degree * -1)
 	if err != nil {
-		return fmt.Errorf("error while attempting to swirl: %w", err)
+		return nil, fmt.Errorf("error while attempting to swirl: %w", err)
 	}
 
 	err = wand.LiquidRescaleImage(width, height, 1, 0)
 	if err != nil {
-		return fmt.Errorf("error while attempting to liquid rescale: %w", err)
+		return nil, fmt.Errorf("error while attempting to liquid rescale: %w", err)
 	}
 
-	_, err = dest.Write(wand.GetImageBlob())
-	if err != nil {
-		return fmt.Errorf("error writing image: %w", err)
-	}
-
-	return nil
+	return []*imagick.MagickWand{wand}, nil
 }

--- a/bot/steve_point.go
+++ b/bot/steve_point.go
@@ -3,7 +3,6 @@ package bot
 import (
 	_ "embed"
 	"fmt"
-	"io"
 
 	"gopkg.in/gographics/imagick.v2/imagick"
 )
@@ -20,24 +19,18 @@ func (args StevePointArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-func StevePoint(srcBytes []byte, destBuffer io.Writer, args StevePointArgs) error {
+func StevePoint(wand *imagick.MagickWand, args StevePointArgs) ([]*imagick.MagickWand, error) {
 	steve := imagick.NewMagickWand()
 	err := steve.ReadImageBlob(stevePointImage)
 	if err != nil {
-		return fmt.Errorf("error reading steve: %w", err)
+		return nil, fmt.Errorf("error reading steve: %w", err)
 	}
 
 	if args.Flip {
 		err = steve.FlopImage()
 		if err != nil {
-			return fmt.Errorf("error flipping steve: %w", err)
+			return nil, fmt.Errorf("error flipping steve: %w", err)
 		}
-	}
-
-	wand := imagick.NewMagickWand()
-	err = wand.ReadImageBlob(srcBytes)
-	if err != nil {
-		return fmt.Errorf("error reading input image: %w", err)
 	}
 
 	inputHeight := wand.GetImageHeight()
@@ -56,12 +49,8 @@ func StevePoint(srcBytes []byte, destBuffer io.Writer, args StevePointArgs) erro
 
 	err = wand.CompositeImage(steve, imagick.COMPOSITE_OP_ATOP, xOffset, 0)
 	if err != nil {
-		return fmt.Errorf("error compositing image: %w", err)
+		return nil, fmt.Errorf("error compositing image: %w", err)
 	}
 
-	_, err = destBuffer.Write(wand.GetImageBlob())
-	if err != nil {
-		return fmt.Errorf("error writing output image: %w", err)
-	}
-	return nil
+	return []*imagick.MagickWand{wand}, nil
 }


### PR DESCRIPTION
- Updated the image operation functions to take a wand and return a slice of wands, rather than dealing directly in bytes
  - Existing operations return a 1-length slice, operations can return more than one wand in the slice to create an animation
- Updated the operation utility function to invoke the operation on each frame in the image and collect all the results. If there is more than one wand in the results, it will output a gif instead of a jpeg
  - This makes it so you can (in theory) run any command against any image, gif or not
  - Animating operators (returning multiple wands) ran against a static image will produce a gif
  - Animating operators ran against a gif will produce a longer gif
  - Static operators (returning a single wand) ran against a static image will produce a static image
  - Static operators ran against a gif will apply the operator to every frame in the gif, resulting in another gif
- Add a new Gmagik command. Runs multiple iterations of magik and produces a gif of the result