### PR TITLE
Add ability to customize width & height multiplier for magik

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -65,6 +65,7 @@ func New() (*Borik, error) {
 	log.Debug().Msg("Registering commands")
 	_ = parser.NewCommand("", "Magikify an image.", MakeImageOpCommand(Magik))
 	_ = parser.NewCommand("magik", "Magikify an image.", MakeImageOpCommand(Magik))
+	_ = parser.NewCommand("lagik", "Lagikify an image.", MakeImageOpCommand(Lagik))
 	_ = parser.NewCommand("gmagik", "Repeatedly magikify an image.", MakeImageOpCommand(Gmagik))
 	_ = parser.NewCommand("arcweld", "Arc-weld an image.", MakeImageOpCommand(Arcweld))
 	_ = parser.NewCommand("malt", "Malt an image.", MakeImageOpCommand(Malt))

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -65,7 +65,6 @@ func New() (*Borik, error) {
 	log.Debug().Msg("Registering commands")
 	_ = parser.NewCommand("", "Magikify an image.", MakeImageOpCommand(Magik))
 	_ = parser.NewCommand("magik", "Magikify an image.", MakeImageOpCommand(Magik))
-	_ = parser.NewCommand("lagik", "Lagikify an image.", MakeImageOpCommand(Lagik))
 	_ = parser.NewCommand("gmagik", "Repeatedly magikify an image.", MakeImageOpCommand(Gmagik))
 	_ = parser.NewCommand("arcweld", "Arc-weld an image.", MakeImageOpCommand(Arcweld))
 	_ = parser.NewCommand("malt", "Malt an image.", MakeImageOpCommand(Malt))

--- a/bot/magik.go
+++ b/bot/magik.go
@@ -17,11 +17,11 @@ func (args MagikArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-func magikHelper(wand *imagick.MagickWand, args MagikArgs, wMultiplier float64, hMultiplier float64) ([]*imagick.MagickWand, error) {
+func magikHelper(wand *imagick.MagickWand, args MagikArgs) ([]*imagick.MagickWand, error) {
 	width := wand.GetImageWidth()
 	height := wand.GetImageHeight()
 
-	err := wand.LiquidRescaleImage(uint(float64(width)*wMultiplier), uint(float64(height)*hMultiplier), args.Scale, 0)
+	err := wand.LiquidRescaleImage(uint(float64(width)*args.WidthMultiplier), uint(float64(height)*args.HeightMultiplier), args.Scale, 0)
 	if err != nil {
 		return nil, fmt.Errorf("error while attempting to liquid rescale: %w", err)
 	}
@@ -36,5 +36,27 @@ func magikHelper(wand *imagick.MagickWand, args MagikArgs, wMultiplier float64, 
 
 // Magik runs content-aware scaling on an image.
 func Magik(wand *imagick.MagickWand, args MagikArgs) ([]*imagick.MagickWand, error) {
-	return magikHelper(wand, args, args.WidthMultiplier, args.HeightMultiplier)
+	return magikHelper(wand, args)
+}
+
+type LagikArgs struct {
+	ImageURL string  `default:"" description:"URL to the image to process. Leave blank to automatically attempt to find an image."`
+	Scale    float64 `default:"1" description:"Scale of the magikification. Larger numbers produce more destroyed images."`
+}
+
+func (args LagikArgs) GetImageURL() string {
+	return args.ImageURL
+}
+
+// Lagik runs content-aware scaling on an image.
+func Lagik(wand *imagick.MagickWand, args LagikArgs) ([]*imagick.MagickWand, error) {
+	return magikHelper(
+		wand,
+		MagikArgs{
+			ImageURL:         args.ImageURL,
+			Scale:            args.Scale,
+			WidthMultiplier:  1.5,
+			HeightMultiplier: 1.5,
+		},
+	)
 }

--- a/bot/magik.go
+++ b/bot/magik.go
@@ -7,8 +7,10 @@ import (
 )
 
 type MagikArgs struct {
-	ImageURL string  `default:"" description:"URL to the image to process. Leave blank to automatically attempt to find an image."`
-	Scale    float64 `default:"1" description:"Scale of the magikification. Larger numbers produce more destroyed images."`
+	ImageURL         string  `default:"" description:"URL to the image to process. Leave blank to automatically attempt to find an image."`
+	Scale            float64 `default:"1" description:"Scale of the magikification. Larger numbers produce more destroyed images."`
+	WidthMultiplier  float64 `default:"0.5" description:"Multiplier to apply to the width of the input image to produce the intermediary image."`
+	HeightMultiplier float64 `default:"0.5" description:"Multiplier to apply to the height of the input image to produce the intermediary image."`
 }
 
 func (args MagikArgs) GetImageURL() string {
@@ -34,10 +36,5 @@ func magikHelper(wand *imagick.MagickWand, args MagikArgs, wMultiplier float64, 
 
 // Magik runs content-aware scaling on an image.
 func Magik(wand *imagick.MagickWand, args MagikArgs) ([]*imagick.MagickWand, error) {
-	return magikHelper(wand, args, 0.5, 0.5)
-}
-
-// Lagik runs content-aware scaling on an image.
-func Lagik(wand *imagick.MagickWand, args MagikArgs) ([]*imagick.MagickWand, error) {
-	return magikHelper(wand, args, 1.5, 1.5)
+	return magikHelper(wand, args, args.WidthMultiplier, args.HeightMultiplier)
 }


### PR DESCRIPTION
# Changes
- Add two new params to `borik!magik` - `WidthMultiplier` and `HeightMultiplier` - which expose the previously hardcoded `0.5` scale multiplier to the user as a tweakable parameter. This returns functionality that previously existed in Borob but is missing in Borik
- Remove the `lagik` command, as it was just a different multiplier value for `magik`