### PR TITLE
Fetch images from referenced messages

### DIFF
--- a/bot/utilities.go
+++ b/bot/utilities.go
@@ -81,6 +81,12 @@ func FindImageURL(m *discordgo.MessageCreate) (string, error) {
 		return imageUrl, nil
 	}
 
+	if m.ReferencedMessage != nil {
+		if imageUrl := ImageURLFromMessage(m.ReferencedMessage); imageUrl != "" {
+			return imageUrl, nil
+		}
+	}
+
 	messages, err := Instance.Session.ChannelMessages(m.ChannelID, 20, m.ID, "", "")
 	if err != nil {
 		return "", fmt.Errorf("error retrieving message history: %w", err)


### PR DESCRIPTION
Resolves #37 

Enable image discovery to fetch images from referenced messages. This allows users to invoke borik commands via replies to messages containing images to operate on those images.