### PR TITLE
add liblcms2-dev to the dockerfile to fix hdr cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
       libgif-dev \
       libwebp-dev \
       libheif-dev \
+      liblcms2-dev \
       liblqr-1-0-dev \
       libglib2.0 \
       ghostscript \


### PR DESCRIPTION
supposedly imagemagick needs this for -profile and such