### PR TITLE
Fix number of zoom steps for aizoom

### DIFF
--- a/pkg/bot/image_gen.go
+++ b/pkg/bot/image_gen.go
@@ -255,7 +255,7 @@ func FlipFlop(wand *imagick.MagickWand, args FlipFlopArgs, metadata AISessionMet
 type AiZoomArgs struct {
 	ImageURL string `default:"" description:"URL of the image to edit."`
 	Prompt   string `default:"Expand the image outwards." description:"Prompt to edit the image with."`
-	Steps    uint   `default:"3" description:"Number of zoom steps to perform."`
+	Steps    uint   `default:"2" description:"Number of zoom steps to perform."`
 }
 
 func (args AiZoomArgs) GetImageURL() string {

--- a/pkg/bot/image_gen.go
+++ b/pkg/bot/image_gen.go
@@ -255,7 +255,7 @@ func FlipFlop(wand *imagick.MagickWand, args FlipFlopArgs, metadata AISessionMet
 type AiZoomArgs struct {
 	ImageURL string `default:"" description:"URL of the image to edit."`
 	Prompt   string `default:"Expand the image outwards." description:"Prompt to edit the image with."`
-	Steps    uint   `default:"20" description:"Number of zoom steps to perform."`
+	Steps    uint   `default:"3" description:"Number of zoom steps to perform."`
 }
 
 func (args AiZoomArgs) GetImageURL() string {


### PR DESCRIPTION
Decrease zoom steps from 20 to 2. I have no clue why I set it to 20, but it basically broke it.