### PR TITLE
Gifify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
       ghostscript \
       libfreetype6-dev \
       libfontconfig1-dev \
+      ffmpeg \
       --no-install-recommends && \
     wget https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz && \
 	tar xvzf ${IMAGEMAGICK_VERSION}.tar.gz && \

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
             buildInputs = [
               pkgs.go
               pkgs.gotools
+              pkgs.ffmpeg
               pkgs.imagemagick
               pkgs.pkg-config
             ];
@@ -32,8 +33,13 @@
             inherit version;
             src = ./.;
 
-            nativeBuildInputs = [ pkgs.pkg-config ];
+            nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];
             buildInputs = [ pkgs.imagemagick ];
+
+            postInstall = ''
+              wrapProgram $out/bin/borik \
+                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.ffmpeg ]}
+            '';
 
             vendorSha256 = "sha256-TL+1hALB3iQRkitrBVXz1QuLdYadvwkcKHChrYSPD0I=";
 

--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -180,6 +180,12 @@ var commands = []Command{
 		slashHandler: MakeImageOpSlashCommand(HueCycle),
 	},
 	{
+		name:         "gif",
+		description:  "Convert a video to a GIF.",
+		textHandler:  GifTextCommand,
+		slashHandler: GifSlashCommand,
+	},
+	{
 		name:         "modulate",
 		description:  "Modify the brightness, saturation, and hue of an image.",
 		textHandler:  MakeImageOpTextCommand(Modulate),

--- a/pkg/bot/gif.go
+++ b/pkg/bot/gif.go
@@ -1,0 +1,173 @@
+package bot
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/rs/zerolog/log"
+)
+
+type GifArgs struct {
+	VideoURL string  `default:"" description:"URL to the video to process. Leave blank to automatically attempt to find a video."`
+	FPS      uint    `default:"15" description:"Frames per second for the GIF."`
+	Width    uint    `default:"480" description:"Width of the GIF in pixels. Height is scaled to preserve aspect ratio."`
+	Duration float64 `default:"10" description:"Maximum video duration to convert, in seconds. Set to 0 to convert the whole video."`
+}
+
+// GifTextCommand converts a video to a GIF from a text command.
+func GifTextCommand(message *discordgo.MessageCreate, args GifArgs) {
+	PrepareAndInvokeGif(NewOperationContextFromMessage(Instance.session, message), args)
+}
+
+// GifSlashCommand converts a video to a GIF from a slash command.
+func GifSlashCommand(session *discordgo.Session, interaction *discordgo.InteractionCreate, args GifArgs) {
+	PrepareAndInvokeGif(NewOperationContextFromInteraction(session, interaction), args)
+}
+
+// PrepareAndInvokeGif locates a video, converts it to a GIF, and uploads the result.
+func PrepareAndInvokeGif(ctx *OperationContext, args GifArgs) {
+	defer TypingIndicatorForContext(ctx)()
+
+	if err := ctx.DeferResponse(); err != nil {
+		log.Error().Err(err).Msg("Failed to defer response")
+		return
+	}
+
+	videoURL := args.VideoURL
+	if videoURL == "" {
+		var err error
+		videoURL, err = ctx.FindVideoURL()
+		if err != nil {
+			log.Error().Err(err).Msg("Error while attempting to find video to process")
+			return
+		}
+	}
+
+	srcBytes, err := DownloadImage(videoURL)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to download video to process")
+		return
+	}
+
+	parsedURL, _ := url.Parse(videoURL)
+	inputFile, err := os.CreateTemp("", "borik-gif-input-*"+path.Ext(parsedURL.Path))
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create temporary video file")
+		return
+	}
+	inputPath := inputFile.Name()
+	defer func() {
+		if err := os.Remove(inputPath); err != nil {
+			log.Error().Err(err).Msg("Failed to remove temporary video file")
+		}
+	}()
+
+	if _, err := inputFile.Write(srcBytes); err != nil {
+		log.Error().Err(err).Msg("Failed to write temporary video file")
+		_ = inputFile.Close()
+		return
+	}
+	if err := inputFile.Close(); err != nil {
+		log.Error().Err(err).Msg("Failed to close temporary video file")
+		return
+	}
+
+	outputFile, err := os.CreateTemp("", "borik-gif-output-*.gif")
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create temporary GIF file")
+		return
+	}
+	outputPath := outputFile.Name()
+	if err := outputFile.Close(); err != nil {
+		log.Error().Err(err).Msg("Failed to close temporary GIF file")
+		return
+	}
+	defer func() {
+		if err := os.Remove(outputPath); err != nil {
+			log.Error().Err(err).Msg("Failed to remove temporary GIF file")
+		}
+	}()
+
+	if err := convertVideoToGIF(inputPath, outputPath, args); err != nil {
+		log.Error().Err(err).Msg("Failed to convert video to GIF")
+		if sendErr := ctx.SendText(fmt.Sprintf("Failed to convert video to GIF: `%s`", err.Error())); sendErr != nil {
+			log.Error().Err(sendErr).Msg("Failed to send error message")
+		}
+		return
+	}
+
+	gifBytes, err := os.ReadFile(outputPath)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read output GIF")
+		return
+	}
+
+	originalFileName := path.Base(parsedURL.Path)
+	if originalFileName == "." || originalFileName == "/" {
+		originalFileName = "video"
+	}
+	originalFileNameNoExt := strings.TrimSuffix(originalFileName, path.Ext(originalFileName))
+	resultFileName := fmt.Sprintf("%s.gif", originalFileNameNoExt)
+
+	log.Debug().Msg("GIF processed, uploading result")
+	err = ctx.SendFiles([]*discordgo.File{
+		{
+			Name:        resultFileName,
+			ContentType: "image/gif",
+			Reader:      bytes.NewReader(gifBytes),
+		},
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to send GIF")
+		if sendErr := ctx.SendText(fmt.Sprintf("Failed to send resulting GIF: `%s`", err.Error())); sendErr != nil {
+			log.Error().Err(sendErr).Msg("Failed to send error message")
+		}
+	}
+}
+
+func convertVideoToGIF(inputPath string, outputPath string, args GifArgs) error {
+	if args.FPS == 0 {
+		return fmt.Errorf("fps must be greater than 0")
+	}
+	if args.Width == 0 {
+		return fmt.Errorf("width must be greater than 0")
+	}
+
+	ffmpegArgs := []string{
+		"-hide_banner",
+		"-loglevel", "error",
+	}
+	if args.Duration > 0 {
+		ffmpegArgs = append(ffmpegArgs, "-t", fmt.Sprintf("%.3f", args.Duration))
+	}
+
+	filter := fmt.Sprintf(
+		"fps=%d,scale=%d:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse",
+		args.FPS,
+		args.Width,
+	)
+	ffmpegArgs = append(ffmpegArgs,
+		"-i", inputPath,
+		"-vf", filter,
+		"-loop", "0",
+		"-y",
+		outputPath,
+	)
+
+	output, err := exec.Command("ffmpeg", ffmpegArgs...).CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return fmt.Errorf("ffmpeg failed: %s", message)
+	}
+
+	return nil
+}

--- a/pkg/bot/gif.go
+++ b/pkg/bot/gif.go
@@ -15,8 +15,8 @@ import (
 
 type GifArgs struct {
 	VideoURL string  `default:"" description:"URL to the video to process. Leave blank to automatically attempt to find a video."`
-	FPS      uint    `default:"15" description:"Frames per second for the GIF."`
-	Width    uint    `default:"480" description:"Width of the GIF in pixels. Height is scaled to preserve aspect ratio."`
+	FPS      uint    `default:"10" description:"Frames per second for the GIF."`
+	Width    uint    `default:"320" description:"Width of the GIF in pixels. Height is scaled to preserve aspect ratio."`
 	Duration float64 `default:"10" description:"Maximum video duration to convert, in seconds. Set to 0 to convert the whole video."`
 }
 

--- a/pkg/bot/utilities.go
+++ b/pkg/bot/utilities.go
@@ -164,6 +164,14 @@ func (ctx *OperationContext) FindImageURL() (string, error) {
 	return FindImageURLInChannel(ctx.Session, ctx.Interaction.ChannelID, "")
 }
 
+// FindVideoURL attempts to locate a video URL from the context.
+func (ctx *OperationContext) FindVideoURL() (string, error) {
+	if ctx.Message != nil {
+		return FindVideoURLFromMessage(ctx.Message)
+	}
+	return FindVideoURLInChannel(ctx.Session, ctx.Interaction.ChannelID, "")
+}
+
 func TypingIndicatorForContext(ctx *OperationContext) func() {
 	if ctx.Message != nil {
 		return TypingIndicator(ctx.Message)
@@ -256,6 +264,46 @@ func ImageURLFromMessage(m *discordgo.Message) string {
 	return ""
 }
 
+// VideoURLFromMessage attempts to retrieve a video URL from a given message.
+func VideoURLFromMessage(m *discordgo.Message) string {
+	for _, embed := range m.Embeds {
+		if embed.Video != nil && embed.Video.URL != "" {
+			return embed.Video.URL
+		}
+		if (embed.Type == discordgo.EmbedTypeVideo || embed.Type == discordgo.EmbedTypeGifv) && embed.URL != "" {
+			return embed.URL
+		}
+	}
+
+	for _, attachment := range m.Attachments {
+		if IsVideoAttachment(attachment) {
+			return attachment.URL
+		}
+	}
+
+	for _, component := range m.Components {
+		url := ImageURLFromComponent(component)
+		if url != "" {
+			return url
+		}
+	}
+
+	return ""
+}
+
+func IsVideoAttachment(attachment *discordgo.MessageAttachment) bool {
+	if strings.HasPrefix(attachment.ContentType, "video/") {
+		return true
+	}
+
+	switch strings.ToLower(path.Ext(attachment.Filename)) {
+	case ".avi", ".m4v", ".mkv", ".mov", ".mp4", ".webm":
+		return true
+	default:
+		return false
+	}
+}
+
 // FindImageURLFromMessage attempts to find an image in a given message, falling back to scanning message history if one cannot be found.
 func FindImageURLFromMessage(m *discordgo.MessageCreate) (string, error) {
 	if imageUrl := ImageURLFromMessage(m.Message); imageUrl != "" {
@@ -271,6 +319,21 @@ func FindImageURLFromMessage(m *discordgo.MessageCreate) (string, error) {
 	return FindImageURLInChannel(Instance.session, m.ChannelID, m.ID)
 }
 
+// FindVideoURLFromMessage attempts to find a video in a given message, falling back to scanning message history if one cannot be found.
+func FindVideoURLFromMessage(m *discordgo.MessageCreate) (string, error) {
+	if videoUrl := VideoURLFromMessage(m.Message); videoUrl != "" {
+		return videoUrl, nil
+	}
+
+	if m.ReferencedMessage != nil {
+		if videoUrl := VideoURLFromMessage(m.ReferencedMessage); videoUrl != "" {
+			return videoUrl, nil
+		}
+	}
+
+	return FindVideoURLInChannel(Instance.session, m.ChannelID, m.ID)
+}
+
 func FindImageURLInChannel(s *discordgo.Session, channelID string, beforeID string) (string, error) {
 	messages, err := s.ChannelMessages(channelID, 20, beforeID, "", "")
 	if err != nil {
@@ -283,6 +346,20 @@ func FindImageURLInChannel(s *discordgo.Session, channelID string, beforeID stri
 		}
 	}
 	return "", errors.New("unable to locate an image")
+}
+
+func FindVideoURLInChannel(s *discordgo.Session, channelID string, beforeID string) (string, error) {
+	messages, err := s.ChannelMessages(channelID, 20, beforeID, "", "")
+	if err != nil {
+		return "", fmt.Errorf("error retrieving message history: %w", err)
+	}
+
+	for _, message := range messages {
+		if videoUrl := VideoURLFromMessage(message); videoUrl != "" {
+			return videoUrl, nil
+		}
+	}
+	return "", errors.New("unable to locate a video")
 }
 
 // DownloadImage downloads an image from a given URL, returning the resulting bytes.
@@ -724,4 +801,3 @@ func MakeImageOverlayOp(overlayImage []byte, initialOptions OverlayOptions) Imag
 		return []*imagick.MagickWand{wand}, err
 	}
 }
-


### PR DESCRIPTION
Add a new command, `borik!gif`, which converts a video to a gif using ffmpeg. This is optimized for those resulting gifs to then be used with other borik commands. I opted not to just do this on the fly when running a command to:
- not add the extra overhead of running ffmpeg
- not change existing behaviour

Disclaimer: This PR is 100% the work of GPT 5.5 and Codex