### PR TITLE
Detect media URLs in message content

### DIFF
--- a/pkg/bot/utilities.go
+++ b/pkg/bot/utilities.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"math"
 	"math/rand/v2"
+	"mime"
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -21,6 +23,8 @@ import (
 type ImageOperationArgs interface {
 	GetImageURL() string
 }
+
+var messageURLRegex = regexp.MustCompile(`(?i)https?://[^\s<>"']+`)
 
 type ImageOperation[K ImageOperationArgs] func(*imagick.MagickWand, K) ([]*imagick.MagickWand, error)
 
@@ -238,6 +242,23 @@ func ImageURLFromComponent(component discordgo.MessageComponent) string {
 	}
 }
 
+func mediaURLFromContent(content string, contentTypePrefix string) string {
+	for _, candidate := range messageURLRegex.FindAllString(content, -1) {
+		candidate = strings.TrimRight(candidate, ".,!?;:)]}")
+		parsedURL, err := url.Parse(candidate)
+		if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+			continue
+		}
+
+		contentType := mime.TypeByExtension(strings.ToLower(path.Ext(parsedURL.Path)))
+		if strings.HasPrefix(contentType, contentTypePrefix) {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
 // ImageURLFromMessage attempts to retrieve an image URL from a given message.
 func ImageURLFromMessage(m *discordgo.Message) string {
 	for _, embed := range m.Embeds {
@@ -259,6 +280,10 @@ func ImageURLFromMessage(m *discordgo.Message) string {
 		if url != "" {
 			return url
 		}
+	}
+
+	if url := mediaURLFromContent(m.Content, "image/"); url != "" {
+		return url
 	}
 
 	return ""
@@ -288,6 +313,10 @@ func VideoURLFromMessage(m *discordgo.Message) string {
 		}
 	}
 
+	if url := mediaURLFromContent(m.Content, "video/"); url != "" {
+		return url
+	}
+
 	return ""
 }
 
@@ -296,12 +325,8 @@ func IsVideoAttachment(attachment *discordgo.MessageAttachment) bool {
 		return true
 	}
 
-	switch strings.ToLower(path.Ext(attachment.Filename)) {
-	case ".avi", ".m4v", ".mkv", ".mov", ".mp4", ".webm":
-		return true
-	default:
-		return false
-	}
+	contentType := mime.TypeByExtension(strings.ToLower(path.Ext(attachment.Filename)))
+	return strings.HasPrefix(contentType, "video/")
 }
 
 // FindImageURLFromMessage attempts to find an image in a given message, falling back to scanning message history if one cannot be found.


### PR DESCRIPTION
Last night you copied a link to an attachment into a message, and then tried running a borik command on it. From the perspective of the client, that message was replaced with just the file, but from the perspective of the API that message was just a text message consisting of solely a link.

Now, add to the attachment detection flow to look for messages that contain links that have file extensions that resolve to `image/` or `video/` content types for image and video commands respectively. This won't catch _everything_, but it's a good first pass that doesn't require us to start brute-forcing fetching every URL linked in the discord and looking up their `Content-Type` header

_Disclaimer: This PR is Codex (and GPT 5.5 medium)'s finest. None of this code was written by me_