### PR TITLE
Implement linting

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,16 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  golangci-lint:
+    uses: nint8835/workflows/.github/workflows/golangci-lint.yaml@main

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   IMAGEMAGICK_PREFIX: ${{ github.workspace }}/.cache/imagemagick
-  IMAGEMAGICK_VERSION: 7.1.2-3
 
 jobs:
   golangci-lint:
@@ -33,11 +32,11 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .cache/imagemagick
-          key: imagemagick-${{ runner.os }}-${{ runner.arch }}-${{ env.IMAGEMAGICK_VERSION }}-${{ hashFiles('scripts/install-imagemagick.sh') }}
+          key: imagemagick-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/install-imagemagick.sh') }}
 
       - name: Install ImageMagick 7 development headers
         run: |
-          sudo --preserve-env=IMAGEMAGICK_PREFIX,IMAGEMAGICK_VERSION ./scripts/install-imagemagick.sh
+          sudo --preserve-env=IMAGEMAGICK_PREFIX ./scripts/install-imagemagick.sh
           echo "${IMAGEMAGICK_PREFIX}/bin" >> "$GITHUB_PATH"
           echo "PKG_CONFIG_PATH=${IMAGEMAGICK_PREFIX}/lib/pkgconfig" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=${IMAGEMAGICK_PREFIX}/lib" >> "$GITHUB_ENV"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+env:
+  IMAGEMAGICK_PREFIX: ${{ github.workspace }}/.cache/imagemagick
+  IMAGEMAGICK_VERSION: 7.1.2-3
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest
@@ -25,11 +29,18 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache ImageMagick
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .cache/imagemagick
+          key: imagemagick-${{ runner.os }}-${{ runner.arch }}-${{ env.IMAGEMAGICK_VERSION }}-${{ hashFiles('scripts/install-imagemagick.sh') }}
+
       - name: Install ImageMagick 7 development headers
         run: |
-          sudo ./scripts/install-imagemagick.sh
-          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=/usr/local/lib" >> "$GITHUB_ENV"
+          sudo --preserve-env=IMAGEMAGICK_PREFIX,IMAGEMAGICK_VERSION ./scripts/install-imagemagick.sh
+          echo "${IMAGEMAGICK_PREFIX}/bin" >> "$GITHUB_PATH"
+          echo "PKG_CONFIG_PATH=${IMAGEMAGICK_PREFIX}/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=${IMAGEMAGICK_PREFIX}/lib" >> "$GITHUB_ENV"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -25,10 +25,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install ImageMagick development headers
+      - name: Install ImageMagick 7 development headers
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes libmagickwand-dev pkg-config
+          sudo ./scripts/install-imagemagick.sh
+          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=/usr/local/lib" >> "$GITHUB_ENV"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -8,9 +8,42 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  checks: write
 
 jobs:
   golangci-lint:
-    uses: nint8835/workflows/.github/workflows/golangci-lint.yaml@main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install ImageMagick development headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libmagickwand-dev pkg-config
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          only-new-issues: true
+
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  unpinned-uses:
+    ignore:
+      - docker-image.yml:16

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,29 @@
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - errname
+    - exhaustive
+    - godot
+    - govet
+    - ineffassign
+    - lll
+    - staticcheck
+    - testpackage
+    - unused
+    - usestdlibvars
+    - whitespace
+  exclusions:
+    rules:
+      - linters:
+          - lll
+        source: '^\s*\w+\s+[^`]+`[^`]+`$'
+
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/fogo-sh/borik

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,9 @@ linters:
       - linters:
           - lll
         source: '^\s*\w+\s+[^`]+`[^`]+`$'
+      - linters:
+          - typecheck
+        text: "could not import gopkg.in/gographics/imagick.v3/imagick"
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,9 +19,6 @@ linters:
       - linters:
           - lll
         source: '^\s*\w+\s+[^`]+`[^`]+`$'
-      - linters:
-          - typecheck
-        text: "could not import gopkg.in/gographics/imagick.v3/imagick"
 
 formatters:
   enable:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,29 +3,9 @@ FROM golang:1.25-trixie
 WORKDIR /deps
 ENV IMAGEMAGICK_VERSION=7.1.2-3
 
-RUN apt-get update && \
-    apt-get -q -y install \
-      libjpeg-dev \
-      libpng-dev \
-      libtiff-dev \
-      libgif-dev \
-      libwebp-dev \
-      libheif-dev \
-      liblcms2-dev \
-      liblqr-1-0-dev \
-      libglib2.0 \
-      ghostscript \
-      libfreetype6-dev \
-      libfontconfig1-dev \
-      ffmpeg \
-      --no-install-recommends && \
-    wget https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz && \
-	tar xvzf ${IMAGEMAGICK_VERSION}.tar.gz && \
-	cd ImageMagick* && \
-	./configure && \
-	make -j$(nproc) && make install && \
-	ldconfig /usr/local/lib && \
-    rm -rf /deps
+COPY scripts/install-imagemagick.sh /usr/local/bin/install-imagemagick
+RUN install-imagemagick && \
+    apt-get install --yes --no-install-recommends ffmpeg
 
 WORKDIR /build
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,7 +30,7 @@ var runCmd = &cobra.Command{
 
 		log.Info().Msg("Borik is now running, press CTRL-C to exit.")
 		sc := make(chan os.Signal, 1)
-		signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+		signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 		<-sc
 		log.Info().Msg("Quitting Borik")
 

--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -14,7 +14,7 @@ import (
 	configPkg "github.com/fogo-sh/borik/pkg/config"
 )
 
-// Bot represents an individual instance of Borik
+// Bot represents an individual instance of Borik.
 type Bot struct {
 	session      *discordgo.Session
 	openAiClient openai.Client
@@ -44,7 +44,7 @@ func (b *Bot) Stop() {
 	b.quitChan <- struct{}{}
 }
 
-// Instance is the current instance of Borik
+// Instance is the current instance of Borik.
 var Instance *Bot
 
 type Command struct {

--- a/pkg/bot/deepfry.go
+++ b/pkg/bot/deepfry.go
@@ -18,12 +18,20 @@ func (args DeepfryArgs) GetImageURL() string {
 
 // Deepfry destroys an image via a combination of operations.
 func Deepfry(wand *imagick.MagickWand, args DeepfryArgs) ([]*imagick.MagickWand, error) {
-	err := wand.ResizeImage(wand.GetImageWidth()/args.DownscaleFactor, wand.GetImageHeight()/args.DownscaleFactor, imagick.FILTER_POINT)
+	err := wand.ResizeImage(
+		wand.GetImageWidth()/args.DownscaleFactor,
+		wand.GetImageHeight()/args.DownscaleFactor,
+		imagick.FILTER_POINT,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error resizing image: %w", err)
 	}
 
-	err = wand.ResizeImage(wand.GetImageWidth()*args.DownscaleFactor, wand.GetImageHeight()*args.DownscaleFactor, imagick.FILTER_POINT)
+	err = wand.ResizeImage(
+		wand.GetImageWidth()*args.DownscaleFactor,
+		wand.GetImageHeight()*args.DownscaleFactor,
+		imagick.FILTER_POINT,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error resizing image: %w", err)
 	}

--- a/pkg/bot/graphics_formats.go
+++ b/pkg/bot/graphics_formats.go
@@ -76,7 +76,11 @@ func getPaletteImage(palette []string) (*imagick.MagickWand, error) {
 	return paletteWand, nil
 }
 
-func convertGraphicsFormat(wand *imagick.MagickWand, format graphicsFormat, dither bool) ([]*imagick.MagickWand, error) {
+func convertGraphicsFormat(
+	wand *imagick.MagickWand,
+	format graphicsFormat,
+	dither bool,
+) ([]*imagick.MagickWand, error) {
 	paletteWand, err := getPaletteImage(format.Palette)
 	if err != nil {
 		return nil, fmt.Errorf("error getting format palette: %w", err)

--- a/pkg/bot/hdr.go
+++ b/pkg/bot/hdr.go
@@ -11,8 +11,8 @@ import (
 var icc2020Profile []byte
 
 type HdrArgs struct {
-	ImageURL   string  `default:"" description:"URL to the image to process. Leave blank to automatically attempt to find an image."`
-	Multiply   float64 `default:"1.5" description:"Multiplier for pixel values. Higher values produce brighter, more saturated results."`
+	ImageURL      string  `default:"" description:"URL to the image to process. Leave blank to automatically attempt to find an image."`
+	Multiply      float64 `default:"1.5" description:"Multiplier for pixel values. Higher values produce brighter, more saturated results."`
 	GammaExponent float64 `default:"0.9" description:"Exponent for gamma power curve. Lower values brighten midtones more."`
 }
 

--- a/pkg/bot/help.go
+++ b/pkg/bot/help.go
@@ -17,7 +17,13 @@ func generateCommandList() string {
 	commandCodeBlock.WriteString("```")
 
 	for _, details := range Instance.textParser.GetCommands() {
-		commandCodeBlock.WriteString(fmt.Sprintf("%s%s: %s\n", Instance.config.Prefixes[0], details.Name, details.Description))
+		_, _ = fmt.Fprintf(
+			&commandCodeBlock,
+			"%s%s: %s\n",
+			Instance.config.Prefixes[0],
+			details.Name,
+			details.Description,
+		)
 	}
 
 	return commandCodeBlock.String() + "```"

--- a/pkg/bot/huecycle.go
+++ b/pkg/bot/huecycle.go
@@ -15,7 +15,7 @@ func (args HueCycleArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-// HueCycle cycles the hue on an image
+// HueCycle cycles the hue on an image.
 func HueCycle(wand *imagick.MagickWand, args HueCycleArgs) ([]*imagick.MagickWand, error) {
 	wands := []*imagick.MagickWand{wand}
 

--- a/pkg/bot/image_fetch.go
+++ b/pkg/bot/image_fetch.go
@@ -49,7 +49,7 @@ func fetchAvatar(ctx *OperationContext, targetUser *discordgo.User, guildID stri
 		log.Error().Err(err).Msg("Error downloading avatar")
 		return
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, "Error closing avatar response body")
 
 	file := &discordgo.File{
 		Name:        path.Base(resp.Request.URL.Path),
@@ -65,11 +65,14 @@ func fetchAvatar(ctx *OperationContext, targetUser *discordgo.User, guildID stri
 // Avatar fetches a user's avatar.
 func Avatar(message *discordgo.MessageCreate, args AvatarArgs) {
 	if len(message.Mentions) != 1 {
-		Instance.session.ChannelMessageSendReply(
+		_, err := Instance.session.ChannelMessageSendReply(
 			message.ChannelID,
 			"You must provide a single user to fetch an avatar for, as a Discord mention.",
 			message.Reference(),
 		)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to send avatar usage error")
+		}
 		return
 	}
 
@@ -113,6 +116,11 @@ func getStickerUrl(sticker *discordgo.StickerItem) (string, string, error) {
 	case discordgo.StickerFormatTypeAPNG:
 		return fmt.Sprintf(
 			"https://media.discordapp.net/stickers/%s.png?size=1024",
+			sticker.ID,
+		), "image/gif", nil
+	case discordgo.StickerFormatTypeGIF:
+		return fmt.Sprintf(
+			"https://media.discordapp.net/stickers/%s.gif?size=1024",
 			sticker.ID,
 		), "image/gif", nil
 	case discordgo.StickerFormatTypeLottie:
@@ -196,21 +204,28 @@ func Sticker(message *discordgo.MessageCreate, args struct{}) {
 	}
 
 	if targetSticker == nil {
-		Instance.session.ChannelMessageSendReply(
+		_, err := Instance.session.ChannelMessageSendReply(
 			message.ChannelID,
-			"No sticker found! Please post the sticker you are looking for and try again, or retry this command as a reply on the target message.",
+			"No sticker found! Please post the sticker you are looking for and try again, "+
+				"or retry this command as a reply on the target message.",
 			message.Reference(),
 		)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to send missing sticker error")
+		}
 		return
 	}
 
 	stickerUrl, contentType, err := getStickerUrl(targetSticker)
 	if err != nil {
-		Instance.session.ChannelMessageSendReply(
+		_, err := Instance.session.ChannelMessageSendReply(
 			message.ChannelID,
 			fmt.Sprintf("Unable to fetch sticker: %s", err),
 			message.Reference(),
 		)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to send sticker fetch error")
+		}
 		return
 	}
 
@@ -219,18 +234,21 @@ func Sticker(message *discordgo.MessageCreate, args struct{}) {
 		log.Error().Err(err).Msg("Error downloading sticker")
 		return
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, "Error closing sticker response body")
 
 	var file io.Reader
 	var filename string
 	if targetSticker.FormatType == discordgo.StickerFormatTypeAPNG {
 		file, err = apngToGif(resp.Body)
 		if err != nil {
-			Instance.session.ChannelMessageSendReply(
+			_, sendErr := Instance.session.ChannelMessageSendReply(
 				message.ChannelID,
 				fmt.Sprintf("Error converting APNG sticker to GIF:\n```%s```", err),
 				message.Reference(),
 			)
+			if sendErr != nil {
+				log.Error().Err(sendErr).Msg("Failed to send sticker conversion error")
+			}
 			log.Error().Err(err).Msg("Error converting APNG sticker to GIF")
 			return
 		}
@@ -240,7 +258,7 @@ func Sticker(message *discordgo.MessageCreate, args struct{}) {
 		filename = path.Base(resp.Request.URL.Path)
 	}
 
-	Instance.session.ChannelMessageSendComplex(
+	_, err = Instance.session.ChannelMessageSendComplex(
 		message.ChannelID,
 		&discordgo.MessageSend{
 			Reference: message.Reference(),
@@ -251,6 +269,9 @@ func Sticker(message *discordgo.MessageCreate, args struct{}) {
 			},
 		},
 	)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to send sticker")
+	}
 }
 
 func getEmojiUrl(emoji *discordgo.Emoji) string {
@@ -287,11 +308,15 @@ func Emoji(message *discordgo.MessageCreate, args EmojiArgs) {
 	}
 
 	if targetEmoji == nil {
-		Instance.session.ChannelMessageSendReply(
+		_, err := Instance.session.ChannelMessageSendReply(
 			message.ChannelID,
-			"No emoji found! Please post the emoji you are looking for and try again, or retry this command as a reply on the target message.",
+			"No emoji found! Please post the emoji you are looking for and try again, "+
+				"or retry this command as a reply on the target message.",
 			message.Reference(),
 		)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to send missing emoji error")
+		}
 		return
 	}
 
@@ -302,9 +327,9 @@ func Emoji(message *discordgo.MessageCreate, args EmojiArgs) {
 		log.Error().Err(err).Msg("Error downloading emoji")
 		return
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, "Error closing emoji response body")
 
-	Instance.session.ChannelMessageSendComplex(
+	_, err = Instance.session.ChannelMessageSendComplex(
 		message.ChannelID,
 		&discordgo.MessageSend{
 			Reference: message.Reference(),
@@ -315,4 +340,7 @@ func Emoji(message *discordgo.MessageCreate, args EmojiArgs) {
 			},
 		},
 	)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to send emoji")
+	}
 }

--- a/pkg/bot/image_gen.go
+++ b/pkg/bot/image_gen.go
@@ -93,7 +93,12 @@ func ImageGenSlashCommand(session *discordgo.Session, interaction *discordgo.Int
 	generateImage(NewOperationContextFromInteraction(session, interaction), args)
 }
 
-func editImage(wand *imagick.MagickWand, args ImageEditArgs, metadata AISessionMetadata, mask *imagick.MagickWand) (*imagick.MagickWand, error) {
+func editImage(
+	wand *imagick.MagickWand,
+	args ImageEditArgs,
+	metadata AISessionMetadata,
+	mask *imagick.MagickWand,
+) (*imagick.MagickWand, error) {
 	err := ShrinkMaintainAspectRatio(wand, AI_EDIT_MAX_DIMENSION, AI_EDIT_MAX_DIMENSION)
 	if err != nil {
 		return nil, fmt.Errorf("error resizing image: %w", err)
@@ -175,7 +180,11 @@ func (args ImageEditArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-func ImageEdit(wand *imagick.MagickWand, args ImageEditArgs, metadata AISessionMetadata) ([]*imagick.MagickWand, error) {
+func ImageEdit(
+	wand *imagick.MagickWand,
+	args ImageEditArgs,
+	metadata AISessionMetadata,
+) ([]*imagick.MagickWand, error) {
 	editedImage, err := editImage(wand, args, metadata, nil)
 	if err != nil {
 		return nil, err
@@ -262,7 +271,11 @@ func (args AiZoomArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-func performAiZoomStep(wand *imagick.MagickWand, prompt string, metadata AISessionMetadata) (*imagick.MagickWand, error) {
+func performAiZoomStep(
+	wand *imagick.MagickWand,
+	prompt string,
+	metadata AISessionMetadata,
+) (*imagick.MagickWand, error) {
 	originalWidth := wand.GetImageWidth()
 	originalHeight := wand.GetImageHeight()
 
@@ -270,13 +283,18 @@ func performAiZoomStep(wand *imagick.MagickWand, prompt string, metadata AISessi
 
 	var err error
 
-	// If the image can be used as-is without the target canvas exceeding the max size for resizing, do so to not lose quality
-	// Otherwise, shrink it
-	if originalWidth < uint(float64(AI_EDIT_MAX_DIMENSION)*sizeMultiplier) && originalHeight < uint(float64(AI_EDIT_MAX_DIMENSION)*sizeMultiplier) {
+	// If the image can be used as-is without the target canvas exceeding the max size for resizing, use it as-is.
+	// Otherwise, shrink it.
+	maxOriginalDimension := uint(float64(AI_EDIT_MAX_DIMENSION) * sizeMultiplier)
+	if originalWidth < maxOriginalDimension && originalHeight < maxOriginalDimension {
 		originalWidth = uint(float64(originalWidth) / sizeMultiplier)
 		originalHeight = uint(float64(originalHeight) / sizeMultiplier)
 	} else {
-		err = ShrinkMaintainAspectRatio(wand, uint(float64(wand.GetImageWidth())*sizeMultiplier), uint(float64(wand.GetImageHeight())*sizeMultiplier))
+		err = ShrinkMaintainAspectRatio(
+			wand,
+			uint(float64(wand.GetImageWidth())*sizeMultiplier),
+			uint(float64(wand.GetImageHeight())*sizeMultiplier),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error resizing image for zoom: %w", err)
 		}
@@ -300,7 +318,13 @@ func performAiZoomStep(wand *imagick.MagickWand, prompt string, metadata AISessi
 		return nil, fmt.Errorf("error setting canvas alpha channel for zoom: %w", err)
 	}
 
-	err = canvas.CompositeImage(wand, imagick.COMPOSITE_OP_OVER, false, int((originalWidth-wand.GetImageWidth())/2), int((originalHeight-wand.GetImageHeight())/2))
+	err = canvas.CompositeImage(
+		wand,
+		imagick.COMPOSITE_OP_OVER,
+		false,
+		int((originalWidth-wand.GetImageWidth())/2),
+		int((originalHeight-wand.GetImageHeight())/2),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error compositing image onto canvas for zoom: %w", err)
 	}
@@ -345,7 +369,11 @@ func (args AiLoopZoomArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-func AiLoopZoom(wand *imagick.MagickWand, args AiLoopZoomArgs, metadata AISessionMetadata) ([]*imagick.MagickWand, error) {
+func AiLoopZoom(
+	wand *imagick.MagickWand,
+	args AiLoopZoomArgs,
+	metadata AISessionMetadata,
+) ([]*imagick.MagickWand, error) {
 	editedFrames := make([]*imagick.MagickWand, 0, args.Steps+1)
 
 	editedFrames = append(editedFrames, wand)

--- a/pkg/bot/magik.go
+++ b/pkg/bot/magik.go
@@ -21,7 +21,12 @@ func magikHelper(wand *imagick.MagickWand, args MagikArgs) ([]*imagick.MagickWan
 	width := wand.GetImageWidth()
 	height := wand.GetImageHeight()
 
-	err := wand.LiquidRescaleImage(uint(float64(width)*args.WidthMultiplier), uint(float64(height)*args.HeightMultiplier), args.Scale, 0)
+	err := wand.LiquidRescaleImage(
+		uint(float64(width)*args.WidthMultiplier),
+		uint(float64(height)*args.HeightMultiplier),
+		args.Scale,
+		0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error while attempting to liquid rescale: %w", err)
 	}

--- a/pkg/bot/modulate.go
+++ b/pkg/bot/modulate.go
@@ -17,7 +17,7 @@ func (args ModulateArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-// Modulate allows modifying of the brightness, saturation, and hue of an image
+// Modulate allows modifying of the brightness, saturation, and hue of an image.
 func Modulate(wand *imagick.MagickWand, args ModulateArgs) ([]*imagick.MagickWand, error) {
 	err := wand.ModulateImage(args.Brightness, args.Saturation, args.Hue)
 	if err != nil {

--- a/pkg/bot/otsu.go
+++ b/pkg/bot/otsu.go
@@ -15,7 +15,7 @@ func (args OtsuArgs) GetImageURL() string {
 	return args.ImageURL
 }
 
-// Otsu turns the image black and white by applying an adaptive threshold using Otsu's method
+// Otsu turns the image black and white by applying an adaptive threshold using Otsu's method.
 func Otsu(wand *imagick.MagickWand, args OtsuArgs) ([]*imagick.MagickWand, error) {
 	numOfPixels := 0
 	histogram := map[int]int{}
@@ -77,7 +77,8 @@ func Otsu(wand *imagick.MagickWand, args OtsuArgs) ([]*imagick.MagickWand, error
 
 		meanBackground := sumBackground / weightBackground
 		meanForeground := (sum - sumBackground) / weightForeground
-		betweenVariance := weightBackground * weightForeground * (meanBackground - meanForeground) * (meanBackground - meanForeground)
+		meanDelta := meanBackground - meanForeground
+		betweenVariance := weightBackground * weightForeground * meanDelta * meanDelta
 		if betweenVariance > maxVariance {
 			maxVariance = betweenVariance
 			threshold = i

--- a/pkg/bot/overlays.go
+++ b/pkg/bot/overlays.go
@@ -42,46 +42,82 @@ func makeOverlayCommand(name, description string, op ImageOperation[OverlayImage
 
 func generateOverlayCommands() []Command {
 	return []Command{
-		makeOverlayCommand("jackpog", "Have Jack Pog an image.", MakeImageOverlayOp(jackPogImage, OverlayOptions{
-			OverlayWidthFactor:  1,
-			OverlayHeightFactor: 0.5,
-		})),
-		makeOverlayCommand("sidekeenan", "Have Keenan on the side of an image.", MakeImageOverlayOp(sideKeenanImage, OverlayOptions{
-			OverlayWidthFactor:  1,
-			OverlayHeightFactor: 0.5,
-			RightToLeft:         true,
-		})),
-		makeOverlayCommand("keenanthumb", "Have Keenan thumbs-up an image.", MakeImageOverlayOp(keenanThumbImage, OverlayOptions{
-			OverlayWidthFactor:  1,
-			OverlayHeightFactor: 0.5,
-		})),
-		makeOverlayCommand("mitchpoint", "Have Mitch point at an image.", MakeImageOverlayOp(mitchPointImage, OverlayOptions{
-			OverlayWidthFactor:  1,
-			OverlayHeightFactor: 1,
-		})),
-		makeOverlayCommand("stevepoint", "Have Steve point at an image.", MakeImageOverlayOp(stevePointImage, OverlayOptions{
-			OverlayWidthFactor:  1,
-			OverlayHeightFactor: 1,
-			RightToLeft:         true,
-		})),
-		makeOverlayCommand("andrewpog", "Have Andrew Pog an image.", MakeImageOverlayOp(andrewPogImage, OverlayOptions{
-			OverlayWidthFactor:  1,
-			OverlayHeightFactor: 0.75,
-			RightToLeft:         true,
-		})),
-		makeOverlayCommand("matlabkid", "Have matlab kid possess an image", MakeImageOverlayOp(matlabKidImage, OverlayOptions{
-			VFlip:               true,
-			OverlayWidthFactor:  1.2,
-			OverlayHeightFactor: 1.3,
-			RightToLeft:         true,
-		})),
-		makeOverlayCommand("natalieclimb", "Have Natalie climb an image.", MakeImageOverlayOp(natalieClimbImage, OverlayOptions{
-			OverlayWidthFactor:  1,
-			OverlayHeightFactor: 1,
-		})),
-		makeOverlayCommand("dennystanding", "Have Denny standing in an image.", MakeImageOverlayOp(dennyStandingImage, OverlayOptions{
-			OverlayWidthFactor:  0.4,
-			OverlayHeightFactor: 0.6,
-		})),
+		makeOverlayCommand(
+			"jackpog",
+			"Have Jack Pog an image.",
+			MakeImageOverlayOp(jackPogImage, OverlayOptions{
+				OverlayWidthFactor:  1,
+				OverlayHeightFactor: 0.5,
+			}),
+		),
+		makeOverlayCommand(
+			"sidekeenan",
+			"Have Keenan on the side of an image.",
+			MakeImageOverlayOp(sideKeenanImage, OverlayOptions{
+				OverlayWidthFactor:  1,
+				OverlayHeightFactor: 0.5,
+				RightToLeft:         true,
+			}),
+		),
+		makeOverlayCommand(
+			"keenanthumb",
+			"Have Keenan thumbs-up an image.",
+			MakeImageOverlayOp(keenanThumbImage, OverlayOptions{
+				OverlayWidthFactor:  1,
+				OverlayHeightFactor: 0.5,
+			}),
+		),
+		makeOverlayCommand(
+			"mitchpoint",
+			"Have Mitch point at an image.",
+			MakeImageOverlayOp(mitchPointImage, OverlayOptions{
+				OverlayWidthFactor:  1,
+				OverlayHeightFactor: 1,
+			}),
+		),
+		makeOverlayCommand(
+			"stevepoint",
+			"Have Steve point at an image.",
+			MakeImageOverlayOp(stevePointImage, OverlayOptions{
+				OverlayWidthFactor:  1,
+				OverlayHeightFactor: 1,
+				RightToLeft:         true,
+			}),
+		),
+		makeOverlayCommand(
+			"andrewpog",
+			"Have Andrew Pog an image.",
+			MakeImageOverlayOp(andrewPogImage, OverlayOptions{
+				OverlayWidthFactor:  1,
+				OverlayHeightFactor: 0.75,
+				RightToLeft:         true,
+			}),
+		),
+		makeOverlayCommand(
+			"matlabkid",
+			"Have matlab kid possess an image",
+			MakeImageOverlayOp(matlabKidImage, OverlayOptions{
+				VFlip:               true,
+				OverlayWidthFactor:  1.2,
+				OverlayHeightFactor: 1.3,
+				RightToLeft:         true,
+			}),
+		),
+		makeOverlayCommand(
+			"natalieclimb",
+			"Have Natalie climb an image.",
+			MakeImageOverlayOp(natalieClimbImage, OverlayOptions{
+				OverlayWidthFactor:  1,
+				OverlayHeightFactor: 1,
+			}),
+		),
+		makeOverlayCommand(
+			"dennystanding",
+			"Have Denny standing in an image.",
+			MakeImageOverlayOp(dennyStandingImage, OverlayOptions{
+				OverlayWidthFactor:  0.4,
+				OverlayHeightFactor: 0.6,
+			}),
+		),
 	}
 }

--- a/pkg/bot/utilities.go
+++ b/pkg/bot/utilities.go
@@ -51,7 +51,10 @@ func NewOperationContextFromMessage(session *discordgo.Session, message *discord
 	}
 }
 
-func NewOperationContextFromInteraction(session *discordgo.Session, interaction *discordgo.InteractionCreate) *OperationContext {
+func NewOperationContextFromInteraction(
+	session *discordgo.Session,
+	interaction *discordgo.InteractionCreate,
+) *OperationContext {
 	return &OperationContext{
 		Session:     session,
 		Interaction: interaction,
@@ -183,7 +186,7 @@ func TypingIndicatorForContext(ctx *OperationContext) func() {
 	return func() {}
 }
 
-// TypingIndicator invokes a typing indicator in the channel of a message
+// TypingIndicator invokes a typing indicator in the channel of a message.
 func TypingIndicator(message *discordgo.MessageCreate) func() {
 	stopTyping := Schedule(
 		func() {
@@ -201,7 +204,7 @@ func TypingIndicator(message *discordgo.MessageCreate) func() {
 	}
 }
 
-// Schedule some func to be run in a cancelable goroutine on an interval
+// Schedule some func to be run in a cancelable goroutine on an interval.
 func Schedule(what func(), delay time.Duration) chan bool {
 	stop := make(chan bool)
 
@@ -347,6 +350,12 @@ func findMediaURLInChannel(s *discordgo.Session, channelID string, beforeID stri
 	return "", fmt.Errorf("unable to locate a %s", kind.name)
 }
 
+func closeBody(body io.Closer, message string) {
+	if err := body.Close(); err != nil {
+		log.Error().Err(err).Msg(message)
+	}
+}
+
 // DownloadImage downloads an image from a given URL, returning the resulting bytes.
 func DownloadImage(url string) ([]byte, error) {
 	log.Debug().Str("url", url).Msg("Downloading image")
@@ -354,7 +363,7 @@ func DownloadImage(url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error downloading image: %w", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body, "Error closing image response body")
 
 	buffer := new(bytes.Buffer)
 
@@ -366,24 +375,30 @@ func DownloadImage(url string) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// MakeImageOpTextCommand automatically creates a Parsley command handler for a given ImageOperation
+// MakeImageOpTextCommand automatically creates a Parsley command handler for a given ImageOperation.
 func MakeImageOpTextCommand[K ImageOperationArgs](operation ImageOperation[K]) func(*discordgo.MessageCreate, K) {
 	return func(message *discordgo.MessageCreate, args K) {
 		PrepareAndInvokeOperation(NewOperationContextFromMessage(Instance.session, message), args, operation)
 	}
 }
 
-func MakeImageOpSlashCommand[K ImageOperationArgs](operation ImageOperation[K]) func(*discordgo.Session, *discordgo.InteractionCreate, K) {
+func MakeImageOpSlashCommand[K ImageOperationArgs](
+	operation ImageOperation[K],
+) func(*discordgo.Session, *discordgo.InteractionCreate, K) {
 	return func(session *discordgo.Session, interaction *discordgo.InteractionCreate, args K) {
 		PrepareAndInvokeOperation(NewOperationContextFromInteraction(session, interaction), args, operation)
 	}
 }
 
-// AIImageOperation is like ImageOperation but also receives AISessionMetadata for session tracking and seed management
-type AIImageOperation[K ImageOperationArgs] func(*imagick.MagickWand, K, AISessionMetadata) ([]*imagick.MagickWand, error)
+// AIImageOperation is like ImageOperation but also receives AISessionMetadata for session tracking and seed management.
+type AIImageOperation[K ImageOperationArgs] func(
+	*imagick.MagickWand,
+	K,
+	AISessionMetadata,
+) ([]*imagick.MagickWand, error)
 
 // MakeAIImageOpTextCommand creates a Parsley command handler for an AIImageOperation,
-// building full AISessionMetadata (with seed, session ID, user ID) from the OperationContext
+// building full AISessionMetadata (with seed, session ID, user ID) from the OperationContext.
 func MakeAIImageOpTextCommand[K ImageOperationArgs](operation AIImageOperation[K]) func(*discordgo.MessageCreate, K) {
 	return func(message *discordgo.MessageCreate, args K) {
 		ctx := NewOperationContextFromMessage(Instance.session, message)
@@ -399,8 +414,10 @@ func MakeAIImageOpTextCommand[K ImageOperationArgs](operation AIImageOperation[K
 }
 
 // MakeAIImageOpSlashCommand creates a slash command handler for an AIImageOperation,
-// building full AISessionMetadata (with seed, session ID, user ID) from the OperationContext
-func MakeAIImageOpSlashCommand[K ImageOperationArgs](operation AIImageOperation[K]) func(*discordgo.Session, *discordgo.InteractionCreate, K) {
+// building full AISessionMetadata (with seed, session ID, user ID) from the OperationContext.
+func MakeAIImageOpSlashCommand[K ImageOperationArgs](
+	operation AIImageOperation[K],
+) func(*discordgo.Session, *discordgo.InteractionCreate, K) {
 	return func(session *discordgo.Session, interaction *discordgo.InteractionCreate, args K) {
 		ctx := NewOperationContextFromInteraction(session, interaction)
 		metadata := AISessionMetadata{
@@ -414,7 +431,7 @@ func MakeAIImageOpSlashCommand[K ImageOperationArgs](operation AIImageOperation[
 	}
 }
 
-// PrepareAndInvokeOperation automatically handles invoking a given ImageOperation and returning the finished results
+// PrepareAndInvokeOperation automatically handles invoking a given ImageOperation and returning the finished results.
 func PrepareAndInvokeOperation[K ImageOperationArgs](ctx *OperationContext, args K, operation ImageOperation[K]) {
 	defer TypingIndicatorForContext(ctx)()
 
@@ -543,7 +560,7 @@ func PrepareAndInvokeOperation[K ImageOperationArgs](ctx *OperationContext, args
 	}
 }
 
-// FindTransparentOpeningRect finds the bounding rectangle of the transparent region in an image
+// FindTransparentOpeningRect finds the bounding rectangle of the transparent region in an image.
 func FindTransparentOpeningRect(frame *imagick.MagickWand) (x, y, width, height int, err error) {
 	analysis := frame.Clone()
 	defer analysis.Destroy()
@@ -566,7 +583,7 @@ func FindTransparentOpeningRect(frame *imagick.MagickWand) (x, y, width, height 
 	return ox, oy, int(analysis.GetImageWidth()), int(analysis.GetImageHeight()), nil
 }
 
-// ResizeMaintainAspectRatio resizes an input wand to fit within a box of given width and height, maintaining aspect ratio
+// ResizeMaintainAspectRatio resizes an input wand to fit within a box while maintaining aspect ratio.
 func ResizeMaintainAspectRatio(wand *imagick.MagickWand, width uint, height uint) error {
 	inputHeight := float64(wand.GetImageHeight())
 	inputWidth := float64(wand.GetImageWidth())
@@ -582,7 +599,7 @@ func ResizeMaintainAspectRatio(wand *imagick.MagickWand, width uint, height uint
 	return wand.ScaleImage(uint(targetWidth), uint(targetHeight))
 }
 
-// ShrinkMaintainAspectRatio shrinks an input wand to fit within a box of given width and height if it exceeds those dimensions, maintaining aspect ratio
+// ShrinkMaintainAspectRatio shrinks an input wand to fit within a box if it exceeds those dimensions.
 func ShrinkMaintainAspectRatio(wand *imagick.MagickWand, width uint, height uint) error {
 	inputHeight := float64(wand.GetImageHeight())
 	inputWidth := float64(wand.GetImageWidth())
@@ -644,7 +661,12 @@ type FrameOptions struct {
 
 // FrameImage places wand into the given opening of a frame, resizing according to options,
 // centering on a white background, and compositing behind the frame.
-func FrameImage(wand *imagick.MagickWand, frame *imagick.MagickWand, openX, openY, openW, openH int, options FrameOptions) ([]*imagick.MagickWand, error) {
+func FrameImage(
+	wand *imagick.MagickWand,
+	frame *imagick.MagickWand,
+	openX, openY, openW, openH int,
+	options FrameOptions,
+) ([]*imagick.MagickWand, error) {
 	switch options.FitMode {
 	case FitModeStretch:
 		if err := wand.ResizeImage(uint(openW), uint(openH), imagick.FILTER_LANCZOS); err != nil {
@@ -703,7 +725,7 @@ func MakeImageFrameOp(frameBytes []byte, options FrameOptions) ImageOperation[Fr
 	}
 }
 
-// OverlayImage overlays an image onto another image
+// OverlayImage overlays an image onto another image.
 func OverlayImage(wand *imagick.MagickWand, overlay []byte, options OverlayOptions) error {
 	overlayWand := imagick.NewMagickWand()
 	err := overlayWand.ReadImageBlob(overlay)

--- a/pkg/bot/waaw.go
+++ b/pkg/bot/waaw.go
@@ -83,7 +83,6 @@ func mirrorImage(wand *imagick.MagickWand, direction mirrorDirection, flipped bo
 	}
 
 	return []*imagick.MagickWand{wand}, nil
-
 }
 
 type WaawArgs struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,7 @@ import (
 
 // Prefixes is a custom type for command prefixes, split on "|" to allow
 // commas and other special characters as prefix values.
-// Example: BORIK_PREFIXES="borik!|,"
+// Example: BORIK_PREFIXES="borik!|,".
 type Prefixes []string
 
 func (p *Prefixes) Decode(value string) error {
@@ -21,7 +21,7 @@ func (p *Prefixes) Decode(value string) error {
 	return nil
 }
 
-// Config represents the config that Borik will use to run
+// Config represents the config that Borik will use to run.
 type Config struct {
 	Prefixes Prefixes `default:"borik!"`
 	Token    string   `required:"true"`

--- a/scripts/install-imagemagick.sh
+++ b/scripts/install-imagemagick.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 IMAGEMAGICK_VERSION="${IMAGEMAGICK_VERSION:-7.1.2-3}"
+PREFIX="${IMAGEMAGICK_PREFIX:-/usr/local}"
 WORKDIR="${IMAGEMAGICK_BUILD_DIR:-/tmp/borik-imagemagick-build}"
 
 apt-get update
@@ -23,6 +24,11 @@ apt-get install --yes --no-install-recommends \
   pkg-config \
   wget
 
+if [ -x "${PREFIX}/bin/magick" ] && "${PREFIX}/bin/magick" -version | grep -q "ImageMagick ${IMAGEMAGICK_VERSION}"; then
+  ldconfig "${PREFIX}/lib"
+  exit 0
+fi
+
 rm -rf "${WORKDIR}"
 mkdir -p "${WORKDIR}"
 cd "${WORKDIR}"
@@ -31,9 +37,9 @@ wget "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.
 tar xzf "${IMAGEMAGICK_VERSION}.tar.gz"
 cd "ImageMagick-${IMAGEMAGICK_VERSION}"
 
-./configure
+./configure --prefix="${PREFIX}"
 make -j"$(nproc)"
 make install
-ldconfig /usr/local/lib
+ldconfig "${PREFIX}/lib"
 
 rm -rf "${WORKDIR}"

--- a/scripts/install-imagemagick.sh
+++ b/scripts/install-imagemagick.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGEMAGICK_VERSION="${IMAGEMAGICK_VERSION:-7.1.2-3}"
+WORKDIR="${IMAGEMAGICK_BUILD_DIR:-/tmp/borik-imagemagick-build}"
+
+apt-get update
+apt-get install --yes --no-install-recommends \
+  build-essential \
+  ghostscript \
+  libfontconfig1-dev \
+  libfreetype6-dev \
+  libgif-dev \
+  libglib2.0-0 \
+  libglib2.0-dev \
+  libheif-dev \
+  libjpeg-dev \
+  liblcms2-dev \
+  liblqr-1-0-dev \
+  libpng-dev \
+  libtiff-dev \
+  libwebp-dev \
+  pkg-config \
+  wget
+
+rm -rf "${WORKDIR}"
+mkdir -p "${WORKDIR}"
+cd "${WORKDIR}"
+
+wget "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz"
+tar xzf "${IMAGEMAGICK_VERSION}.tar.gz"
+cd "ImageMagick-${IMAGEMAGICK_VERSION}"
+
+./configure
+make -j"$(nproc)"
+make install
+ldconfig /usr/local/lib
+
+rm -rf "${WORKDIR}"


### PR DESCRIPTION
Implement golangci-lint for this repo & resolve all existing issues. As I'm doing more AI-driven development on Borik, I'd like more opportunities for the AI to be able to catch issues without my involvement.

This PR became _a bit_ more of an ordeal than expected because golangci-lint wants to be able to compile your code. Since we depend on imagick which depends on ImageMagick 7 I couldn't just use my super simple reusable workflow for running golangci-lint - we instead need to compile ImageMagick 7 from source in CI. 

To do so, the compilation logic was moved out of the dockerfile and into `install-imagemagick.sh` which is used in both places.

To prevent CI from taking 3+ minutes to lint from waiting for ImageMagick to compile this also implements caching for the ImageMagick build artifacts in the linting workflow, so only the first build of a given version of ImageMagick will need to be compiled from scratch.

Finally, since all this complicated stuff is going on in CI, also set up Zizmor to lint our workflows.